### PR TITLE
refactor: clean up imports and bump Python requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ coverage.xml
 /CLAUDE.md
 a.ipynb
 system_prompt.txt
+uv.lock

--- a/calculator_server.py
+++ b/calculator_server.py
@@ -1,21 +1,17 @@
-from mcp.server.fastmcp import FastMCP
 import argparse
 import math
-import numpy as np
-from scipy import stats
-from sympy import symbols, solve, sympify, diff, integrate, oo, Sum
 from typing import List, Tuple
+
+from mcp.server.fastmcp import FastMCP
+import numpy as np
 import matplotlib.pyplot as plt
 import sympy as sp
-import numpy as np
-import matplotlib.pyplot as plt
-from sympy import integrate as sympy_integrate
+from scipy import stats
+from sympy import symbols, solve, sympify, diff, oo, Sum
 
 # Create MCP Server
 app = FastMCP(
-    title="Mathematical Calculator",
-    description="A server for complex mathematical calculations",
-    version="1.0.0",
+    name="Mathematical Calculator",
     dependencies=["numpy", "scipy", "sympy", "matplotlib"],
 )
 
@@ -244,7 +240,7 @@ def integrate(expression: str, variable: str = "x") -> dict:
     try:
         var = symbols(variable)
         expr = sympify(expression)
-        result = sympy_integrate(expr, var)  # Use sympy_integrate instead of integrate
+        result = sp.integrate(expr, var)
         return {"result": str(result)}
     except Exception as e:
         return {"error": str(e)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "calculator-mcp-server"
 version = "1.0.0"
 description = "A server for complex mathematical calculations"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=0.4.1",
     "numpy>=2.2.0",


### PR DESCRIPTION
Fix  FastMCP  args (name instead of title in the new versions)
Remove duplicate imports
Resolve sympy naming conflicts
initialization, and bump minimum Python version from 3.9 to 3.10.